### PR TITLE
Add UNKNOWN state LED animation

### DIFF
--- a/inc/jd_io.h
+++ b/inc/jd_io.h
@@ -21,6 +21,7 @@ void jd_status_handle_packet(jd_packet_t *pkt);
 #define JD_STATUS_CONNECTED 2
 #define JD_STATUS_DISCONNECTED 3
 #define JD_STATUS_IDENTIFY 4
+#define JD_STATUS_UNKNOWN_STATE 5
 
 // if disabled with JD_CONFIG_STATUS==0, the user has to provide their own impl.
 void jd_status(int status);

--- a/services/jd_status_light.c
+++ b/services/jd_status_light.c
@@ -46,8 +46,9 @@ static const struct status_anim jd_status_animations[] = {
     // the time on CONNECTED is used in only used with a non-RGB LED; note that there's already a
     // ~30us overhead
     {.color = {0, 255, 0, 0}, .time = 100},          // CONNECTED
-    {.color = {255, 0, 0, 100}, .time = 500 * 1000}, // DICONNECTED
+    {.color = {255, 0, 0, 100}, .time = 500 * 1000}, // DISCONNECTED
     {.color = {0, 0, 255, 0}, .time = 50 * 1000},    // IDENTIFY
+    {.color = {255, 255, 0, 100}, .time = 500 * 1000},    // UNKNOWN STATE
 };
 
 typedef struct {
@@ -210,6 +211,7 @@ void jd_status_init() {
     rgbled_show(state);
 }
 
+// definitions for @status are contained in jd_io.h
 void jd_status(int status) {
     status_ctx_t *state = &status_ctx;
 


### PR DESCRIPTION
Used for when a device requires a user action (e.g. when an external h/w device needs to be connected)