### PR TITLE
add optional app_process callback

### DIFF
--- a/inc/interfaces/jd_app.h
+++ b/inc/interfaces/jd_app.h
@@ -3,8 +3,20 @@
 
 #pragma once
 
+#include "jd_config.h"
+
 /**
  * This function configures firmware for a given module.
  * It's typically the only function that changes between modules.
  */
 void app_init_services(void);
+
+#if JD_CONFIG_APP_PROCESS_HOOK == 1
+/**
+ * This is an optionally implementable callback invoked in main.c.
+ * It allows apps to perform meta-level configuration detection.
+ * This is useful for devices that may need to dynamically detect
+ * hardware changes at runtime (e.g. XAC module).
+ */
+void app_process(void);
+#endif

--- a/inc/jd_config.h
+++ b/inc/jd_config.h
@@ -46,6 +46,10 @@
 #define JD_CONFIG_STATUS 1
 #endif
 
+#ifndef JD_CONFIG_APP_PROCESS_HOOK
+#define JD_CONFIG_APP_PROCESS_HOOK 0
+#endif
+
 #define CONCAT_1(a, b) a##b
 #define CONCAT_0(a, b) CONCAT_1(a, b)
 #ifndef STATIC_ASSERT


### PR DESCRIPTION
Can be enabled through setting JD_CONFIG_APP_PROCESS_HOOK to 1 in board.h (which is then passed to jd_user_config.h)