### PR TITLE
Replace #pragma once with traditional #ifndef guard

### DIFF
--- a/inc/click/drv_digital_in.h
+++ b/inc/click/drv_digital_in.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef DRV_DIGITAL_IN_H
+#define DRV_DIGITAL_IN_H
 #include "drv_name.h"
 
 typedef struct {
@@ -14,3 +15,4 @@ static inline int digital_in_init(digital_in_t *in, pin_name_t name) {
 static inline uint8_t digital_in_read(digital_in_t *in) {
     return pin_get(in->pin);
 }
+#endif

--- a/inc/click/drv_digital_out.h
+++ b/inc/click/drv_digital_out.h
@@ -1,4 +1,6 @@
-#pragma once
+#ifndef DRV_DIGITAL_OUT_H
+#define DRV_DIGITAL_OUT_H
+
 #include "drv_name.h"
 
 typedef struct {
@@ -26,3 +28,5 @@ static inline void digital_out_toggle(digital_out_t *out) {
 static inline void digital_out_write(digital_out_t *out, uint8_t value) {
     pin_set(out->pin, value);
 }
+
+#endif

--- a/inc/click/drv_i2c_master.h
+++ b/inc/click/drv_i2c_master.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef DRV_I2C_MASTER_H
+#define DRV_I2C_MASTER_H
 
 #include "drv_name.h"
 
@@ -66,3 +67,5 @@ static inline int i2c_master_write_then_read(i2c_master_t *obj, const uint8_t *w
 }
 
 static inline void i2c_master_close(i2c_master_t *obj) {}
+
+#endif

--- a/inc/click/drv_name.h
+++ b/inc/click/drv_name.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef DRV_NAME_H
+#define DRV_NAME_H
 
 #include "jd_drivers.h"
 
@@ -112,3 +113,5 @@ static inline void Delay_1sec(void) {
 static inline void Delay_ms(int ms) {
     jd_services_sleep_us(ms * 1000);
 }
+
+#endif

--- a/inc/interfaces/jd_app.h
+++ b/inc/interfaces/jd_app.h
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#pragma once
+#ifndef JD_APP_H
+#define
 
 #include "jd_config.h"
 
@@ -18,3 +19,5 @@ void app_init_services(void);
  * hardware changes at runtime (e.g. XAC module).
  */
 void app_process(void);
+
+#endif

--- a/inc/interfaces/jd_hw.h
+++ b/inc/interfaces/jd_hw.h
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#pragma once
+#ifndef JD_HW_H
+#define JD_HW_H
 
 /*
  * Hardware abstraction layer.
@@ -96,5 +97,7 @@ void one_init(void);
 int one_reset(void);
 void one_write(uint8_t b);
 uint8_t one_read(void);
+
+#endif
 
 #endif

--- a/inc/interfaces/jd_lora.h
+++ b/inc/interfaces/jd_lora.h
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#pragma once
+#ifndef JD_LORA_H
+#define JD_LORA_H
 
 #include "jd_config.h"
 #include "jd_physical.h"
@@ -12,4 +13,6 @@ void jd_lora_init(void);
 #else
 #define jd_lora_process() ((void)0)
 #define jd_lora_init() ((void)0)
+#endif
+
 #endif

--- a/inc/interfaces/jd_rx.h
+++ b/inc/interfaces/jd_rx.h
@@ -5,10 +5,13 @@
  * A reception queue for JD packets.
  */
 
-#pragma once
+#ifndef JD_RX_H
+#define JD_RX_H
 
 #include "jd_service_framework.h"
 
 void jd_rx_init(void);
 int jd_rx_frame_received(jd_frame_t *frame);
 jd_frame_t* jd_rx_get_frame(void);
+
+#endif

--- a/inc/interfaces/jd_tx.h
+++ b/inc/interfaces/jd_tx.h
@@ -4,8 +4,8 @@
 /*
  * A transmission queue for JD packets.
  */
-
-#pragma once
+#ifndef JD_TX_H
+#define JD_TX_H
 
 #include "jd_service_framework.h"
 
@@ -38,4 +38,6 @@ void jd_process_event_queue(void);
 #if JD_RAW_FRAME
 extern uint8_t rawFrameSending;
 extern jd_frame_t *rawFrame;
+#endif
+
 #endif

--- a/inc/jd_control.h
+++ b/inc/jd_control.h
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#pragma once
+#ifndef JD_CONTROL_H
+#define JD_CONTROL_H
 
 #include "jd_config.h"
 #include "jd_physical.h"
@@ -21,3 +22,5 @@ void jd_ctrl_init(void);
 void jd_ctrl_process(srv_t *_state);
 void jd_ctrl_handle_packet(srv_t *_state, jd_packet_t *pkt);
 void dump_pkt(jd_packet_t *pkt, const char *msg);
+
+#endif

--- a/inc/jd_drivers.h
+++ b/inc/jd_drivers.h
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#pragma once
+#ifndef JD_DRIVERS_H
+#define JD_DRIVERS_H
 
 #include "jd_service_framework.h"
 #include "interfaces/jd_hw.h"
@@ -31,3 +32,5 @@
     ENV_INIT_N(init, sleep, 1);
 
 #define ENV_INIT_PTRS(n) .init = init##n, .sleep = sleep##n
+
+#endif

--- a/inc/jd_io.h
+++ b/inc/jd_io.h
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#pragma once
+#ifndef JD_IO_H
+#define JD_IO_H
 
 #include "jd_config.h"
 
@@ -26,3 +27,5 @@ void jd_status_set_ch(int ch, uint8_t v);
 
 // if disabled with JD_CONFIG_STATUS==0, the user has to provide their own impl.
 void jd_status(int status);
+
+#endif

--- a/inc/jd_protocol.h
+++ b/inc/jd_protocol.h
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#pragma once
+#ifndef JD_PROTOCOL_H
+#define JD_PROTOCOL_H
 
 #include "jd_control.h"
 #include "jd_physical.h"
@@ -16,3 +17,5 @@
 #include "interfaces/jd_lora.h"
 
 void jd_init(void);
+
+#endif

--- a/inc/jd_service_classes.h
+++ b/inc/jd_service_classes.h
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#pragma once
+#ifndef JD_SERVICE_CLASSES_H
+#define JD_SERVICE_CLASSES_H
 
 // legacy/temporary only
 #define JD_SERVICE_CLASS_MONO_DISPLAY 0x1f43e195
 #define JD_SERVICE_CLASS_TOUCHBUTTON 0x130cf5be
+
+#endif

--- a/inc/jd_service_framework.h
+++ b/inc/jd_service_framework.h
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#pragma once
+#ifndef JD_SERVICE_FRAMEWORK_H
+#define JD_SERVICE_FRAMEWORK_H
 
 #include "jd_config.h"
 #include "jd_service_classes.h"
@@ -174,3 +175,5 @@ uint32_t app_get_device_class(void);
 #define SRV_ALLOC(id)                                                                              \
     srv_t *state = jd_allocate_service(&id##_vt);                                                  \
     (void)state;
+
+#endif

--- a/inc/jd_util.h
+++ b/inc/jd_util.h
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#pragma once
+#ifndef JD_UTIL_H
+#define JD_UTIL_H
 
 #include "jd_physical.h"
 
@@ -32,3 +33,5 @@ static inline bool in_future(uint32_t moment) {
     extern uint32_t now;
     return ((moment - now) >> 29) == 0;
 }
+
+#endif


### PR DESCRIPTION
While `#pragma once`  is quite efficient, it is not supported by all compilers, specifically Microchip's XC8 compiler. I have therefore replaced these with the more tedious, but traditional `#undef` guards.