### PR TITLE
add events if joystick present

### DIFF
--- a/services/gamepad.c
+++ b/services/gamepad.c
@@ -126,4 +126,10 @@ void gamepad_init(const gamepad_params_t *params) {
             }
         }
     }
+
+    // if we have a joystick then need to add in the generated events 
+    if (state->params.pinX != 0xff) {
+          state->params.buttons_available != 
+            (JD_GAMEPAD_BUTTONS_LEFT | JD_GAMEPAD_BUTTONS_UP | JD_GAMEPAD_BUTTONS_RIGHT | JD_GAMEPAD_BUTTONS_DOWN);
+    }
 }


### PR DESCRIPTION
if there is a joystick on gamepad, it will generate events UP/DOWN/LEFT/RIGHT, but these are not listed in the buttons_available register.