### PR TITLE
led won't off if module without pin power

### DIFF
--- a/services/leddisplay.c
+++ b/services/leddisplay.c
@@ -65,6 +65,7 @@ void leddisplay_process(srv_t *state) {
     if (state->dirty && !state->in_tx) {
         state->dirty = 0;
         state->auto_refresh = now + (64 << 10);
+#if PIN_PWR >= 0
         if (!state->needs_clear &&
             is_empty((uint32_t *)state->pxbuffer, PX_WORDS(state->numpixels))) {
             jd_power_enable(0);
@@ -72,6 +73,7 @@ void leddisplay_process(srv_t *state) {
         } else {
             jd_power_enable(1);
         }
+#endif
         state->in_tx = 1;
         state->needs_clear = 0;
         pwr_enter_pll();

--- a/services/ledstrip.c
+++ b/services/ledstrip.c
@@ -512,12 +512,14 @@ void ledstrip_process(srv_t *state) {
     if (state->dirty && !state->in_tx) {
         state->dirty = 0;
         state->auto_refresh = now + (64 << 10);
+#if PIN_PWR >= 0
         if (is_empty((uint32_t *)state->pxbuffer, PX_WORDS(state->numpixels))) {
             jd_power_enable(0);
             return;
         } else {
             jd_power_enable(1);
         }
+#endif
         state->in_tx = 1;
         pwr_enter_pll();
         limit_intensity(state);


### PR DESCRIPTION
this should resolve https://github.com/microsoft/jacdac/issues/1319 

In some cases a led / display module may not have power pin, so keep flushing pixel data even all leds are off.