### PR TITLE
Firmware Version Generation Bug (commit-based versioning)

### DIFF
--- a/scripts/git-version.sh
+++ b/scripts/git-version.sh
@@ -1,14 +1,18 @@
 #!/bin/sh
 D=`date +%Y%m%d-%H%M`
 TAG=`git describe --dirty --tags --match 'v[0-9]*' --always | sed -e 's/^v//; s/-dirty/-'"$D/"`
-SUFF=`echo $TAG | sed -e 's/[^-]*//'`
-if [ "X$SUFF" = "X" ] ; then
-  # if no -hash or -dirty, just take the tag
-  echo "$TAG"
+if [[ "$TAG" =~ ^[0-9a-f]+-[0-9]{8}-[0-9]{4}$ ]]; then
+  echo "$TAG" # Return the hash as is
 else
-  # otherwise, bump the last number of semver
-  # in semver 0.0.7 > 0.0.7-something (think 0.0.7-rc4)
-  PREF=`echo $TAG | sed -e 's/-.*//; s/\(.*\)\.[0-9]*/\1/'`
-  LAST=`echo $TAG | sed -e 's/-.*//; s/.*\.//'`
-  echo "$PREF.$(($LAST+1))$SUFF"
+  SUFF=`echo $TAG | sed -e 's/[^-]*//'`
+  if [ "X$SUFF" = "X" ] ; then
+    # if no -hash or -dirty, just take the tag
+    echo "$TAG"
+  else
+    # otherwise, bump the last number of semver
+    # in semver 0.0.7 > 0.0.7-something (think 0.0.7-rc4)
+    PREF=`echo $TAG | sed -e 's/-.*//; s/\(.*\)\.[0-9]*/\1/'`
+    LAST=`echo $TAG | sed -e 's/-.*//; s/.*\.//'`
+    echo "$PREF.$(($LAST+1))$SUFF"
+  fi
 fi

--- a/scripts/git-version.sh
+++ b/scripts/git-version.sh
@@ -2,7 +2,7 @@
 D=`date +%Y%m%d-%H%M`
 TAG=`git describe --dirty --tags --match 'v[0-9]*' --always | sed -e 's/^v//; s/-dirty/-'"$D/"`
 if [[ "$TAG" =~ ^[0-9a-f]+-[0-9]{8}-[0-9]{4}$ ]]; then
-  echo "$TAG" # Return the hash as is
+  echo "$TAG" # use as is when based on commit i.e. v959x563-20250321-1122 (v<commit>-<date>-<time>)
 else
   SUFF=`echo $TAG | sed -e 's/[^-]*//'`
   if [ "X$SUFF" = "X" ] ; then


### PR DESCRIPTION
Do not process the version ID if it's generated based on commit rather than tag i.e. v959x563-20250321-1122. Previously it would try to iterate it, giving an error and causing the version to be simply "v".

`./git-version.sh: line 16: 959x563: value too great for base (error token is "959x563")`