### PR TITLE
revamp the lightbulb service to allow changing brightness

### DIFF
--- a/services/jd_services.h
+++ b/services/jd_services.h
@@ -259,7 +259,7 @@ typedef struct motion_cfg {
 } motion_cfg_t;
 void motion_init(const motion_cfg_t *cfg);
 
-void lightbulb_init(uint8_t pin);
+void lightbulb_init(uint8_t pin, const uint16_t *pbrightness_to_pwmLookupTable);
 
 typedef struct {
     void (*init)(void);

--- a/services/lightbulb.c
+++ b/services/lightbulb.c
@@ -2,63 +2,79 @@
 #include "interfaces/jd_pins.h"
 #include "jacdac/dist/c/lightbulb.h"
 #include "interfaces/jd_pwm.h"
+#include "..\..\jacdac-stm32x0\\bl\blutil.h"
+#include "..\..\jacdac-stm32x0\stm32\jdstm.h"
+
+#define PRESCALER 1     // 1:1 division of the timer clock.
+#define PWM_PERIOD 4096 // Timer counts from 0 to (PWM_PERIOD - 1).
+#define DEFAULT_BRIGHTNESS_U08 0
+
+REG_DEFINITION(                                        
+    bulb_regs,                         
+    REG_SRV_COMMON,                                    
+    REG_U8(JD_LIGHT_BULB_REG_BRIGHTNESS), 
+)
+
 
 struct srv_state {
     SRV_COMMON;
-    uint16_t intensity;
-    uint8_t dimmable;
+    uint8_t brightnessU08;
+
+    // end of registers
     uint8_t pin;
-    uint8_t active_lo;
-    uint8_t pwm_id;
+    uint8_t pwm;
+    uint8_t brightness;
+    const uint16_t *pbrightness_to_pwmLookupTable;
 };
 
-REG_DEFINITION(                            //
-    bulb_regs,                             //
-    REG_SRV_COMMON,                        //
-    REG_U16(JD_LIGHT_BULB_REG_BRIGHTNESS), //
-    REG_U8(JD_LIGHT_BULB_REG_DIMMABLE),    //
-)
 
-static void reflect_register_state(srv_t *state) {
-    if (state->intensity) {
-        if (state->dimmable) {
-            uint16_t v = state->intensity >> 6;
-            if (state->active_lo)
-                v = 1023 - v;
-            state->pwm_id = jd_pwm_init(state->pin, 1024, v, cpu_mhz / 16);
-        } else {
-            pin_setup_output(state->pin);
-            pin_set(state->pin, state->active_lo ? 0 : 1);
+
+// Function to get PWM value from brightness
+uint16_t get_pwm_from_brightness(srv_t *state, uint8_t brightness) {
+    if (state->pbrightness_to_pwmLookupTable != NULL)
+        return state->pbrightness_to_pwmLookupTable[brightness];
+    else
+        return PWM_PERIOD;
+}
+
+
+
+void bulb_process(srv_t *state) {    
+
+}
+
+
+
+void bulb_handle_packet(srv_t *state, jd_packet_t *pkt) {
+    if (service_handle_register_final(state, pkt, bulb_regs) == JD_LED_STRIP_REG_BRIGHTNESS) {
+        uint8_t prevBrightness = state->brightness;
+        state->brightness = (state->brightnessU08 * 100 + 128) / 256;
+
+        uint16_t pwmDuty = get_pwm_from_brightness(state, state->brightness);
+        jd_pwm_set_duty(state->pwm, pwmDuty);
+
+        if (state->brightness == 0 && prevBrightness > 0) {
+            jd_pwm_enable(state->pwm, 0);
+        } else if (state->brightness > 0 && prevBrightness == 0) {
+            jd_pwm_enable(state->pwm, 1);
         }
-    } else {
-        pin_setup_input(state->pin, state->active_lo ? PIN_PULL_UP : PIN_PULL_DOWN);
+        return;
     }
 }
 
-void bulb_process(srv_t *state) {
-    (void)state;
-}
 
-void bulb_handle_packet(srv_t *state, jd_packet_t *pkt) {
-    service_handle_register_final(state, pkt, bulb_regs);
-    reflect_register_state(state);
-}
+
 
 SRV_DEF(bulb, JD_SERVICE_CLASS_LIGHT_BULB);
-void lightbulb_init(const uint8_t pin) {
+void lightbulb_init(const uint8_t pin, const uint16_t *pbrightness_to_pwmLookupTable) {
     SRV_ALLOC(bulb);
     state->pin = pin;
-    pin_setup_input(state->pin, PIN_PULL_DOWN);
-    state->dimmable = 0;
-}
+    state->pbrightness_to_pwmLookupTable = pbrightness_to_pwmLookupTable;
 
-#if JD_DCFG
-void lightbulb_config(void) {
-    lightbulb_init(jd_srvcfg_pin("pin"));
-    srv_t *state = jd_srvcfg_last_service();
-    state->active_lo = jd_srvcfg_has_flag("activeLow");
-    if (jd_srvcfg_has_flag("dimmable"))
-        state->dimmable = 1;
-    reflect_register_state(state);
+    pin_setup_output(state->pin);
+    pin_set(state->pin, 0);
+    state->brightnessU08 = DEFAULT_BRIGHTNESS_U08;
+
+    state->pwm = jd_pwm_init(state->pin, PWM_PERIOD, 0, 1);
+    jd_pwm_enable(state->pwm, 0);
 }
-#endif


### PR DESCRIPTION
@GJSea wrote the code. There don't seem to be any devices using the lightbulb service and it's not stable so hopefully it's reasonable to change the c code. It seems like brightness control was supposed to be a feature of the service and that is what we have added. Let us know if you would like us to create an entirely new service instead.

I'm unable to properly test this code because of the build errors described in [microsoft/jacdac-stm32x0/#51](https://github.com/microsoft/jacdac-stm32x0/issues/51). It's working with an earlier version of jacdac-c and jacdac-stm32x0, I think using the commits referenced in jacdac-msr-modules.